### PR TITLE
Update config.lua

### DIFF
--- a/EventHorizon_Deathknight/config.lua
+++ b/EventHorizon_Deathknight/config.lua
@@ -89,7 +89,7 @@ function EventHorizon:InitializeClass()
 	  requiredTree = 1,
 	  requiredTalent = 9,
 	  cooldown = 48707,
-	  playerbuff = {205725},
+	  playerbuff = {205725,5},
 	})
 
 	-- Vampiric Blood

--- a/EventHorizon_Deathknight/config.lua
+++ b/EventHorizon_Deathknight/config.lua
@@ -1,148 +1,296 @@
 function EventHorizon:InitializeClass()
-	self.config.gcdSpellID = 49895
-	
-	-- -- General Abilities (DoTs)
-    
-        -- -- Icy Touch
-        -- self:newSpell({
-            -- debuff = {55095,3},
-            -- refreshable = true,
-            -- hasted = false,
-            -- cooldown = 77575,
-            -- requiredTalentUnselected = 19, -- Hidden when Necrotic Plague is talented
-        -- })
-        
-        -- -- Plague Strike
-        -- self:newSpell({
-            -- debuff = {55078,3},
-            -- refreshable = true,
-            -- hasted = false,
-            -- cooldown = 77575,
-            -- requiredTalentUnselected = 19,
-        -- })
-        
-        -- -- Necrotic Plague replaces above two if talented
-        -- self:newSpell({
-            -- debuff = {152281,2},
-            -- refreshable = true,
-            -- hasted = false,
-            -- cooldown = 77575,
-            -- requiredTalent = 19,
-        -- })
-        
-    -- -- Blood Abilities (WHY DOES BLOOD HAVE SO MANY COOLDOWNS!)
-	
-        -- -- Soul Reaper
-        -- self:newSpell({
-            -- cooldown = 114866,
-            -- playerbuff = {50421, 0},
-            -- requiredTree = 1,
-        -- })
-    
-        -- -- Bone Shield
-       	-- self:newSpell({
-            -- playerbuff = 49222,
-            -- cooldown = 49222,
-            -- requiredTree = 1,
-        -- })
-    
-        -- -- Rune Tap
-        -- self:newSpell({
-            -- playerbuff = 171049,
-            -- cooldown = 48982,
-            -- requiredTree = 1,
-        -- })
+	self.config.gcdSpellID = 49998
 
-    
-        -- -- CDs
-        -- -- Anti-magic Shell
-        -- self:newSpell({
-            -- cooldown = 48707,
-            -- playerbuff = {48707, 0},
-            -- requiredTree = 1,
-        -- })
-        
-        -- -- Vampiric Blood
-        -- self:newSpell({
-            -- cooldown = 55233,
-            -- playerbuff = {55233, 0},
-            -- requiredTree = 1,
-        -- })
-        
-        -- -- Dancing Rune Weapon
-        -- self:newSpell({
-            -- cooldown = 49028,
-            -- playerbuff = {49028, 0},
-            -- requiredTree = 1,
-        -- })
-        
-        -- -- Death Pact
-        -- self:newSpell({
-            -- cooldown = 48743,
-            -- debuff = {48743, 0},
-            -- auraunit = "player",
-            -- requiredTree = 1,
-        -- })
-        
-        -- -- Icebound Fortitude
-        -- self:newSpell({
-            -- cooldown = 48792,
-            -- playerbuff = {48792, 0},
-            -- requiredTree = 1,
-        -- })
-	
-	-- -- Frost tree
-        -- -- Killing Machine
-        -- self:newSpell({
-            -- playerbuff = 51124,
-            -- requiredTree = 2,
-        -- })
-        
-        -- -- Freezing Fog
-        -- self:newSpell({
-            -- playerbuff = 59052,
-            -- requiredTree = 2,
-        -- })
-        
-        -- -- Pillar of Frost
-        -- self:newSpell({
-            -- playerbuff = 51271,
-            -- cooldown = 51271,
-            -- requiredTree = 2,
-        -- })
-        
-	
-	-- -- Unholy tree
-       
-        -- -- Sudden Doom
-        -- self:newSpell({
-            -- playerbuff = 81340,
-            -- requiredTree = 3,
-        -- })
-        
-        -- -- Shadow Infusion + Dark Transformation (Yes, they're exclusive)
-        -- self:newSpell({
-            -- playerbuff = {{91342,0},{63560,0}},
-            -- auraunit = 'pet',
-            -- requiredTree = 3,
-        -- })
+	-- Blood
 
-    -- -- All Specs
-    
-        -- -- Blood Tap/Runic Corruption
-        -- self:newSpell({
-            -- playerbuff = {{114851,0}, {51460, 0}},
-            -- requiredTree = 1,
-        -- })
-        
-        -- -- Death and Decay/Defile
-        -- self:newSpell({
-            -- cooldown = {43265, 152280},
-        -- })
-        
-        -- -- Plague Leech/Unholy Blight
-        -- self:newSpell({
-            -- cooldown = {123693, 115989},
-            -- playerbuff = 115989,
-        -- })
+	-- Blood Plague & Blood Boil
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredLevel = 55,
+	  debuff = {55078,3},
+	  cooldown = 50842,
+	})
+
+	-- Death and Decay & Crimson Scourge
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredLevel = 56,
+	  cooldown = 43265,
+	  playerbuff = 81136,
+	})
+
+	-- Blooddrinker
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 3,
+	  cooldown = 206931,
+	  debuff = 206931,
+	})
+
+	-- Bonestorm
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 19,
+	  cooldown = 194844,
+	  debuff = 196528,
+	})
+
+	-- Blood Mirror
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 20,
+	  cooldown = 206977,
+	  debuff = 206977,
+	})
+
+	-- Marrowrend/Bone Shield & Consumption
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredLevel = 55,
+	  playerbuff = 195181,
+	  cooldown = 205223,
+	})
+
+	-- Mark of Blood
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 10,
+	  cooldown = 206940,
+	  debuff = 206940,
+	})
+
+	-- Tombstone
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 12,
+	  cooldown = 219809,
+	  playerbuff = 219809,
+	})
+
+	-- Rune Tap
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 17,
+	  cooldown = 194679,
+	  playerbuff = 194679,
+	})
+
+	-- Anti-Magic Shell
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredLevel = 57,
+	  requiredTalentUnselected = 9,
+	  cooldown = 48707,
+	  playerbuff = {48707},
+	})
+
+	-- Anti-Magic Shell
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 9,
+	  cooldown = 48707,
+	  playerbuff = {205725},
+	})
+
+	-- Vampiric Blood
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredLevel = 57,
+	  cooldown = 55233,
+	  playerbuff = 55233,
+	})
+
+	--Dancing Rune Weapon
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredLevel = 57,
+	  cooldown = 49028,
+	  playerbuff = 49028,
+	})
+
+	-- Frost
+
+	-- Frost Fever
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 55,
+	  debuff = {55095,3},
+	})
+
+	-- Glacial Advance
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredTalent = 21,
+	  cooldown = 194913,
+	})
+
+	-- Pillar of Frost
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 57,
+	  cooldown = 51271,
+	  playerbuff = 51271,
+	})
+
+	-- Razorice & Horn of Winter
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 57,
+	  debuff = {51714,0},
+	  cooldown = 57330,
+	})
+
+	-- Remorseless Winter
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 57,
+	  cooldown = 196770,
+	  debuff = 196770,
+	})
+
+	-- Empower Rune Weapon
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 57,
+	  cooldown = 47568,
+	})
+
+	-- Obliteration
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredTalent = 19,
+	  cooldown = 207256,
+	  playerbuff = 207256,
+	})
+
+	-- Breath of Sindragosa
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredTalent = 20,
+	  channel = 152279,
+	  cooldown = 152279,
+	})
+
+	-- Remove the --[[ and ]]-- from any of the damage reduction spells you'd like to track in Frost spec.
+--[[
+	-- Anti-Magic Shell
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 57,
+	  cooldown = 48707,
+	  playerbuff = 48707,
+	})
+]]--
+
+--[[
+	-- Icebound Fortitude
+	self:newSpell({
+	  requiredTree = 2,
+	  requiredLevel = 65,
+	  cooldown = 48792,
+	  playerbuff = 48792,
+	})
+]]--
+
+	-- Unholy
+
+	-- Virulent Plague & Epidemic
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredLevel = 81,
+	  debuff = {191587,3},
+	  cooldown = 207317,
+	  refreshable = true,
+	})
+
+	-- Festering Strike & Blighted Rune Weapon
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredLevel = 57,
+	  debuff = 194310,
+	  cooldown = 194918,
+	})
+
+	-- Death and Decay & Sudden Doom
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredLevel = 74,
+	  requiredTalentUnselected = 20,
+	  cooldown = 43265,
+	  playerbuff = 49530,
+	  --icon = 47541,
+	})
+
+	-- Defile & Sudden Doom
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredTalent = 20,
+	  cooldown = 152280,
+	  playerbuff = 49530,
+	  --icon = 47541,
+	})
+
+	-- Dark Transformation
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredLevel = 74,
+	  cooldown = 63560,
+	  playerbuff = 63560,
+	  auraunit = "pet",
+	})
+
+	-- Apocalypse
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredArtifactTalent = 220143,
+	  cooldown = 220143,
+	})
+
+	-- Summon Gargoyle
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredLevel = 75,
+	  requiredTalentUnselected = 19,
+	  cooldown = 49206,
+	  static = 40,
+	})
+
+	-- Dark Arbiter
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredTalent = 19,
+	  cooldown = 207349,
+	  static = 15,
+	})
+
+	-- Remove the --[[ and ]]-- from any of the damage reduction spells you'd like to track in Unholy spec.
+--[[
+	-- Corpse Shield
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredTalent = 14,
+	  cooldown = 207319,
+	  playerbuff = 207319,
+	})
+]]--
+
+--[[
+	-- Anti-Magic Shell
+	self:newSpell({
+	  requiredTree = 3,
+	  cooldown = 48707,
+	  playerbuff = 48707,
+	})
+]]--
+
+--[[
+	-- Icebound Fortitude
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredLevel = 65,
+	  cooldown = 48792,
+	  playerbuff = 48792,
+	})
+]]--
+
 end


### PR DESCRIPTION
Complete DK config.
Given I don't play a DK it might need tweaking but I'm pretty sure I've got it all in there.
I did level my DK to 100 which helped me catch an error I had with the L100 talents.

Defensive CD for the DPS specs aren't shown by default, players wanting them can shown can follow the comments to make them visible.

Just a note for any adventurous players wanting to grab this before the next release.
This config will error until the next patch of the main addon as `requiredArtifactTalent` isn't handled in v1.9.11, if you really want to try it before the next release you'll need to comment out the Unholy artifact ability.