### PR TITLE
Priest config update 2.

### DIFF
--- a/EventHorizon_Priest/config.lua
+++ b/EventHorizon_Priest/config.lua
@@ -5,26 +5,30 @@ function EventHorizon:InitializeClass()
 
 	-- Discipline
 
-	-- Penance
+	-- Shadow Word: Pain with Smite and Penance CD at half height.
 	self:newSpell({
 	  requiredTree = 1,
-	  cast = 47540,
-	  cooldown = 47540,
-	})
-
-	-- purge of the wicked
-	self:newSpell({
-	  requiredTree = 1,
-	  requiredTalent = 19,
-	  debuff = 204213,
+	  requiredLevel = 4,
+	  requiredTalentUnselected = 19,
+	  debuff = {589, 2},
 	  refreshable = true,
-	  hasted = true,
+	  cast = {585, 186263},
+	  channel = 47540,
+	  cooldown = 47540,
+	  smallCooldown = true,
 	})
 
-	-- Power World: Shield
+	-- Purge the Wicked with Smite and Penance CD at half height.
 	self:newSpell({
 	  requiredTree = 1,
-	  cooldown = 17,
+	  requiredLevel = 4,
+	  requiredTalent = 19,
+	  debuff = {204213, 2},
+	  refreshable = true,
+	  cast = {585, 186263},
+	  channel = 47540,
+	  cooldown = 47540,
+	  smallCooldown = true,
 	})
 
 	-- Schism
@@ -35,18 +39,18 @@ function EventHorizon:InitializeClass()
 	  cooldown = 214621,
 	})
 
-	-- Power word: Solace
+	-- Power Word: Solace
 	self:newSpell({
 	  requiredTree = 1,
 	  requiredTalent = 10,
 	  cooldown = 129250,
 	})
 
-	-- Mindbender
+	-- Divine star
 	self:newSpell({
 	  requiredTree = 1,
-	  requiredTalent = 12,
-	  cooldown = 123040,
+	  requiredTalent = 17,
+	  cooldown = 110744,
 	})
 
 	--Halo
@@ -57,19 +61,44 @@ function EventHorizon:InitializeClass()
 	  cooldown = 120517,
 	})
 
-	-- Divine star
+	-- Mindbender
 	self:newSpell({
 	  requiredTree = 1,
-	  requiredTalent = 17,
-	  cooldown = 110744,
+	  requiredTalent = 12,
+	  cooldown = 123040,
 	})
 
-	-- Atonement
+	-- Light's Wrath
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredArtifactTalent = 207946,
+	  cast = 207946,
+	  cooldown = 207946,
+	})
+
+	-- Power Infusion
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalent = 14,
+	  playerbuff = 10060,
+	  cooldown = 10060,
+	})
+
+	-- Shadowfiend
+	self:newSpell({
+	  requiredTree = 1,
+	  requiredTalentUnselected = 12,
+	  cooldown = 34433,
+	})
+
+	-- Atonement and Power World: Shield CD at half height.
 	self:newSpell({
 	  requiredTree = 1,
 	  playerbuff = 194384,
-	  auraunit = target and 'mouseover' or 'target',
+	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
+	  cooldown = 17,
+	  smallCooldown = true,
 	})
 
 	-- Holy
@@ -80,10 +109,9 @@ function EventHorizon:InitializeClass()
 	  playerbuff = 139,
 	  auraunit = target and 'mouseover' or 'target',
 	  refreshable = true,
-	  hasted = true,
 	})
 
-	--PoM
+	--Prayer of Mending
 	self:newSpell({
 	  requiredTree = 2,
 	  cooldown = 33076,
@@ -126,59 +154,57 @@ function EventHorizon:InitializeClass()
 
 	-- Shadow
 
-	-- Vampiric Touch/Mind Flay/SW:Death CD
+	-- Vampiric Touch & Void Torrent channel and CD at half height.
 	self:newSpell({
 	  requiredTree = 3,
-	  cast = 34914, 
-	  channel = {15407, 3},
+	  cast = 34914,
+	  channel = 205065,
 	  debuff = {34914, 3},
-	  cooldown = 199911,
 	  refreshable = true,
-	  hasted = true,
+	  cooldown = 205065,
+	  smallCooldown = true,
 	  recast = true,
 	})
 
-	-- SW: Pain + Mind Blast
+	-- Shadow Word: Pain & Void Bolt CD.
 	self:newSpell({
 	  requiredTree = 3,
 	  requiredLevel = 4,
 	  debuff = {589, 3},
-	  cast = 8092,
-	  cooldown = 8092,
-	  hasted = true,
-	  refreshable = true,
+	  cooldown = 205448,
+--	  smallCooldown = true,
 	})
 
-	-- Mind Spike
+	-- Mind Blast/Mind Flay/Mind Sear
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredTalentUnselected = 20,
+	  cast = 8092,
+	  channel = {{15407, 3}, {48045, 3}},
+	  cooldown = 8092,
+	  icon = 8092,
+	})
+
+	-- Mind Blast/Mind Sear/Mind Spike
 	self:newSpell({
 	  requiredTree = 3,
 	  requiredTalent = 20,
-	  cast = 73510,
+	  cast = {8092, 73510},
+	  channel = {{15407, 3}, {48045, 3}},
+	  cooldown = 8092,
 	  debuff = 217673,
+	  icon = 8092,
+	  smallCooldown = true,
 	})
 
-	-- Void bolt/Void eruption
+	-- Shadow Word: Death
 	self:newSpell({
 	  requiredTree = 3,
-	  playerbuff = {{228264, 0},{197937, 0}},
-	  cast = 228260,
-	  cooldown = 205448,
+	  requiredLevel = 46,
+	  cooldown = 32379,
 	})
 
-	-- Power Infusion
-	self:newSpell({
-	  requiredTree = 3,
-	  requiredTalent = 16,
-	  cooldown = 10060,
-	})
-
-	-- Shadowfiend / Mindbender
-	self:newSpell({
-	  requiredTree = 3,
-	  cooldown = {200174, 34433},
-	})
-
-	-- SW: Void
+	-- Shadow Word: Void
 	self:newSpell({
 	  requiredTree = 3,
 	  requiredTalent = 3,
@@ -192,6 +218,20 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 17,
 	  cast = 205385,
 	  cooldown = 205385,
+	})
+
+	-- Power Infusion
+	self:newSpell({
+	  requiredTree = 3,
+	  requiredTalent = 16,
+	  playerbuff = 10060,
+	  cooldown = 10060,
+	})
+
+	-- Shadowfiend / Mindbender
+	self:newSpell({
+	  requiredTree = 3,
+	  cooldown = {200174, 34433},
 	})
 
 end


### PR DESCRIPTION
Tweaked Discipline display.
Atonement buff tracking is done via mouseover, the PW:S cooldown is at half height on this bar too.
This isn't the easiest thing to display with Event Horizon, you'll probably want a way of tracking it on your unit frames if you don't already.

Pruned and tweaked what is displayed as Shadow.
It should feel less cluttered and a bit more obvious as to what is being tracked.
Depending on which talents are taken the display can get very big, with a typical raid build it should work well though.

Removed unneeded `hasted = true` lines.