### PR TITLE
Druid config update 8.

### DIFF
--- a/EventHorizon_Druid/config.lua
+++ b/EventHorizon_Druid/config.lua
@@ -1,7 +1,7 @@
 local usemouseover = true	-- Make this false or nil (or just delete the line altogether) to make your healing bars not change when you mouse over something.
 
 function EventHorizon:InitializeClass()
-	self.config.gcdSpellID = 768 -- Cat Form
+	self.config.gcdSpellID = 8921 -- Moonfire
 	self.config.hastedSpellID = {50769,10} -- Revive
 
 	-- Balance bars
@@ -13,6 +13,9 @@ function EventHorizon:InitializeClass()
 	  requiredArtifactTalent = 202767,
 	  recharge = 202767,
 	  cast = {202767, 202768, 202771},
+	  barcolors = {
+		recharge	= {202/255, 161/255, 050/255, 0.5},
+	  },
 	})
 
 	-- Moonfire with Force of Nature or Warrior of Elune cooldown at half height.
@@ -22,8 +25,9 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 10,
 	  debuff = {164812,2},
 	  refreshable = true,
-	  cooldown = {205636, 202425},
-	  smallCooldown = true,
+	  barcolors = {
+		debuffmine	= {050/255, 101/255, 252/255, 0.5}
+	  },
 	})
 
 	-- Sunfire
@@ -33,6 +37,12 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 24,
 	  debuff = {164815,2},
 	  refreshable = true,
+	  cooldown = {205636, 202425},
+	  smallCooldown = true,
+	  barcolors = {
+		debuffmine	= {121/255, 010/255, 000/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Stellar Flare
@@ -42,27 +52,40 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 15,
 	  debuff = {202347,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {111/255, 222/255, 232/255, 0.6}
+	  },
 	})
 
 	-- Starsurge  -- There are two bars for this as it provides two different buffs stacking up to three, the buffs are then consumed by different spell schools separately so both are needed.
-	self:newSpell({
-	  requiredTree = 1,
-	  stance = {0,4},
-	  requiredLevel = 10,
-	  playerbuff = 164547,
-	  cast = 194153,
-	  cooldown = 202359,
-	  smallCooldown = true,
-	})
-
+	-- Fury of Elune CD at half height if chosen.
 	self:newSpell({
 	  requiredTree = 1,
 	  stance = {0,4},
 	  requiredLevel = 10,
 	  playerbuff = 164545,
 	  cast = 190984,
+	  cooldown = 202359,
+	  smallCooldown = true,
+	  barcolors = {
+		playerbuff	= {252/255, 252/255, 090/255, 0.5},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
+	})
+
+	-- Astral Communion CD at half height if chosen.
+	self:newSpell({
+	  requiredTree = 1,
+	  stance = {0,4},
+	  requiredLevel = 10,
+	  playerbuff = 164547,
+	  cast = 194153,
 	  cooldown = 202770,
 	  smallCooldown = true,
+	  barcolors = {
+		playerbuff	= {151/255, 101/255, 161/255, 0.5},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 --	-- Starfall  -- Not really sure if this needs to be tracked as the spell area is very obvious and the buff only affects targets within it.
@@ -83,6 +106,9 @@ function EventHorizon:InitializeClass()
 	   requiredTalent = 7,
 	   debuff = {1822,3},
 	   refreshable = true,
+	  barcolors = {
+		debuffmine	= {191/255, 040/255, 101/255, 0.5}
+	  },
 	})
 
 	-- Rip 
@@ -92,6 +118,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 7,
 	  debuff = {1079,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {252/255, 000/255, 060/255, 0.5},
+	  },
 	})
 
 	-- Guardian Affinity
@@ -102,6 +131,9 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  requiredTalent = 8,
 	  cooldown = 33917,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Thrash 
@@ -112,6 +144,10 @@ function EventHorizon:InitializeClass()
 	  debuff = {77758,3},
 	  cooldown = 77758,
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {070/255, 050/255, 040/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Ironfur
@@ -120,6 +156,9 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  requiredTalent = 8,
 	  playerbuff = 192081,
+	  barcolors = {
+		playerbuff	= {040/255, 070/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Frenzied Regeneration
@@ -129,6 +168,10 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 8,
 	  recharge = 22842,
 	  playerbuff = 22842,
+	  barcolors = {
+		playerbuff	= {101/255, 181/255, 141/255, 0.8},
+		recharge	= {030/255, 222/255, 040/255, 0.4}
+	  },
 	})
 
 	-- Celestial Alignment
@@ -139,6 +182,10 @@ function EventHorizon:InitializeClass()
 	  requiredTalentUnselected = 14,
 	  cooldown = 194223,
 	  playerbuff = 194223,
+	  barcolors = {
+		playerbuff	= {060/255, 121/255, 212/255, 0.9},
+		recharge	= {030/255, 131/255, 060/255, 0.4}
+	  },
 	})
 
 	-- Incarnation: Chosen of Elune
@@ -148,32 +195,44 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 14,
 	  cooldown = 102560,
 	  playerbuff = 102560,
+	  barcolors = {
+		playerbuff	= {060/255, 121/255, 212/255, 0.9},
+		recharge	= {030/255, 131/255, 060/255, 0.4}
+	  },
 	})
 
 	-- Restoration Affinity
 
-	-- Rejuvenation
+	-- Rejuvenation + Swiftmend CD
 	self:newSpell({
 	  requiredTree = 1,
 	  stance = 0,
 	  requiredTalent = 9,
+	  cooldown = 18562,
+	  smallCooldown = true,
 	  playerbuff = {774,3},
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {232/255, 060/255, 202/255, 0.5}
+	  }
 	})
 
---	-- Regrowth + Swiftmend CD
+--	-- Regrowth
 	self:newSpell({
 	  requiredTree = 1,
 	  stance = 0,
 	  requiredTalent = 9,
 	  playerbuff = {8936,2},
-	  cooldown = 18562,
-	  smallCooldown = true,
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
 	  cast = 8936,
 	  recast = true,
+	  barcolors = {
+		casting		= {252/255, 121/255, 000/255, 0.8},
+		playerbuff	= {020/255, 212/255, 050/255, 0.7}
+	  }
 	})
 
 	-- Barkskin
@@ -184,6 +243,10 @@ function EventHorizon:InitializeClass()
 	  stance = {0,1,2,3,4},
 	  requiredLevel = 36,
 	  cooldown = 22812,
+	  barcolors = {
+		playerbuff	= {141/255, 070/255, 030/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 ]]--
 
@@ -195,6 +258,9 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  debuff = {164812,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {050/255, 101/255, 252/255, 0.5}
+	  },
 	})
 
 	-- Savage Roar
@@ -203,6 +269,9 @@ function EventHorizon:InitializeClass()
 	  stance = 2,
 	  requiredTalent = 15,
 	  playerbuff = 52610,
+	  barcolors = {
+		playerbuff	= {232/255, 202/255, 000/255, 0.5}
+	  },
 	})
 
 	-- Rake with Ashamane's Frenzy CD at half height once you get it.
@@ -215,6 +284,10 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  cooldown = 210722,
 	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {202/255, 161/255, 050/255, 0.5},
+		debuffmine	= {191/255, 040/255, 101/255, 0.5}
+	  },
 	})
 
 	-- Rake with faster ticks because of Jagged Wounds. The tick time will need to be adjusted if they change the talent, again.
@@ -227,6 +300,10 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  cooldown = 210722,
 	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {202/255, 161/255, 050/255, 0.5},
+		debuffmine	= {191/255, 040/255, 101/255, 0.5}
+	  },
 	})
 
 	-- Moonfire in cat form with talent.
@@ -236,6 +313,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 3,
 	  debuff = {164812,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {050/255, 101/255, 252/255, 0.5}
+	  },
 	})
 
 	-- Rip with tier two talent cooldowns at half height.
@@ -243,14 +323,18 @@ function EventHorizon:InitializeClass()
 	  requiredTree = 2,
 	  stance = 2,
 	  requiredLevel = 20,
-	  requiredTalentUnselected = 17,
+	  requiredTalent = 16,
 	  debuff = {1079,2},
 	  refreshable = true,
 	  cooldown = {108238, 102280, 102401},
 	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		debuffmine	= {252/255, 000/255, 060/255, 0.5},
+	  },
 	})
 
-	-- Rip with faster ticks because of Jagged Wounds. The tick time will need to be adjusted if they change the talent, again.
+	-- Rip with tier two talent cooldowns at half height & faster ticks because of Jagged Wounds. The tick time will need to be adjusted if they change the talent, again.
 	self:newSpell({
 	  requiredTree = 2,
 	  stance = 2,
@@ -259,6 +343,26 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  cooldown = {108238, 102280, 102401},
 	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		debuffmine	= {252/255, 000/255, 060/255, 0.5},
+	  },
+	})
+
+	-- Rip with Elune's Guidance CD at half height.
+	self:newSpell({
+	  requiredTree = 2,
+	  stance = 2,
+	  requiredLevel = 20,
+	  requiredTalent = 18,
+	  cooldown = 202060,
+	  smallCooldown = true,
+	  debuff = {1079,2},
+	  refreshable = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		debuffmine	= {252/255, 000/255, 060/255, 0.5},
+	  },
 	})
 
 	-- Tiger's Fury
@@ -268,6 +372,10 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 12,
 	  cooldown = 5217,
 	  playerbuff = 5217,
+	  barcolors = {
+		playerbuff	= {252/255, 000/255, 050/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Bloodtalons & Predatory Swiftness, triggered by Regrowth.
@@ -276,6 +384,9 @@ function EventHorizon:InitializeClass()
 	  stance = 2,
 	  requiredTalent = 20,
 	  playerbuff = {{69369},{155672}},
+	  barcolors = {
+		playerbuff	= {030/255, 131/255, 000/255, 0.5}
+	  },
 	})
 
 	-- Thrash with Brutal Slash.
@@ -287,6 +398,10 @@ function EventHorizon:InitializeClass()
 	  debuff = {106830,3},
 	  refreshable = true,
 	  recharge = 202028,
+	  barcolors = {
+		debuffmine	= {222/255, 010/255, 010/255, 0.5},
+		recharge	= {222/255, 070/255, 171/255, 0.4}
+	  },
 	})
 
 	-- Thrash with faster ticks because of Jagged Wounds. The tick time will need to be adjusted if they change the talent, again.
@@ -297,14 +412,10 @@ function EventHorizon:InitializeClass()
 	  debuff = {106830,2},
 	  refreshable = true,
 	  recharge = 202028,
-	})
-
-	-- Elune's Guidance
-	self:newSpell({
-	  requiredTree = 2,
-	  stance = 2,
-	  requiredTalent = 18,
-	  cooldown = 202060,
+	  barcolors = {
+		debuffmine	= {222/255, 010/255, 010/255, 0.5},
+		recharge	= {222/255, 070/255, 171/255, 0.4}
+	  },
 	})
 
 	-- Berserk
@@ -326,16 +437,21 @@ function EventHorizon:InitializeClass()
 	  playerbuff = 106951,
 	})
 
-	-- Omen of Clarity / Moment of Clarity
-	-- Delete the next line and the seventh line, after it, if you'd like OoC/MoC tracking.
+	-- Omen/Moment of Clarity & Survival Instinct recharge
+	-- Delete the next line and the 12th line after it, if you'd like OoC/MoC tracking.
 --[[
 	self:newSpell({
 	  requiredTree = 2,
 	  stance = 2,
 	  requiredLevel = 38,
 	  playerbuff = 135700,
+	  recharge = 61336,
+	  barcolors = {
+		playerbuff	= {040/255, 090/255, 191/255, 0.6},
+		recharge	= {232/255, 161/255, 101/255, 0.3}
+	  }
 	})
-]]--
+--]]
 
 	-- Balance Affinity
 
@@ -346,6 +462,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 7,
 	  debuff = {164812,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {050/255, 101/255, 252/255, 0.5}
+	  },
 	})
 
 	-- Sunfire
@@ -354,6 +473,9 @@ function EventHorizon:InitializeClass()
 	  stance = 4,
 	  requiredTalent = 7,
 	  debuff = {93402,2},
+	  barcolors = {
+		debuffmine	= {121/255, 010/255, 000/255, 0.6},
+	  },
 	})
 
 	-- Starsurge  -- There are two bars for this as it provides two different buffs stacking up to three, the buffs are then consumed by different spell schools separately so both are needed.
@@ -366,6 +488,9 @@ function EventHorizon:InitializeClass()
 	  icon = 164547,
 	  cast = 197626,
 	  recast = true,
+	  barcolors = {
+		playerbuff	= {151/255, 101/255, 161/255, 0.5},
+	  },
 	})
 
 	self:newSpell({
@@ -377,6 +502,9 @@ function EventHorizon:InitializeClass()
 	  icon = 164545,
 	  cast = 197626,
 	  recast = true,
+	  barcolors = {
+		playerbuff	= {252/255, 252/255, 090/255, 0.5},
+	  },
 	})
 
 	-- Guardian Affinity
@@ -387,6 +515,9 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  requiredTalent = 8,
 	  cooldown = 33917,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Thrash 
@@ -397,6 +528,10 @@ function EventHorizon:InitializeClass()
 	  cooldown = 77758,
 	  debuff = {192090,3},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {070/255, 050/255, 040/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Ironfur
@@ -405,6 +540,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 8,
 	  stance = 1,
 	  playerbuff = {192081,6},
+	  barcolors = {
+		playerbuff	= {040/255, 070/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Frenzied Regeneration
@@ -414,32 +552,44 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 8,
 	  recharge = 22842,
 	  playerbuff = 22842,
+	  barcolors = {
+		playerbuff	= {101/255, 181/255, 141/255, 0.8},
+		recharge	= {030/255, 222/255, 040/255, 0.4}
+	  },
 	})
 
 	-- Restoration Affinity
 
-	-- Rejuvenation
+	-- Rejuvenation + Swiftmend CD
 	self:newSpell({
 	  requiredTree = 2,
 	  stance = 0,
 	  requiredTalent = 9,
+	  cooldown = 18562,
+	  smallCooldown = true,
 	  playerbuff = {774,3},
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {232/255, 060/255, 202/255, 0.5}
+	  }
 	})
 
-	-- Regrowth + Swiftmend CD
+--	-- Regrowth
 	self:newSpell({
 	  requiredTree = 2,
 	  stance = 0,
 	  requiredTalent = 9,
 	  playerbuff = {8936,2},
-	  cooldown = 18562,
-	  smallCooldown = true,
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
 	  cast = 8936,
 	  recast = true,
+	  barcolors = {
+		casting		= {252/255, 121/255, 000/255, 0.8},
+		playerbuff	= {020/255, 212/255, 050/255, 0.7}
+	  }
 	})
 
 	-- Guardian bars
@@ -451,6 +601,11 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 10,
 	  cooldown = 33917,
 	  playerbuff = {{93622}, {213708}},
+	  barcolors = {
+		playerbuff	= {240/255, 000/255, 000/255, 0.3},
+		debuffmine	= {190/255, 040/255, 100/255, 0.5},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Thrash
@@ -461,6 +616,10 @@ function EventHorizon:InitializeClass()
 	  debuff = {77758,3},
 	  cooldown = 77758,
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {070/255, 050/255, 040/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Pulverize
@@ -469,6 +628,9 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  requiredTalent = 21,
 	  playerbuff = 158792,
+	  barcolors = {
+		playerbuff	= {030/255, 121/255, 121/255, 0.6},
+	  },
 	})
 
 	-- Moonfire with tier two talent cooldowns at half height.
@@ -480,14 +642,24 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  cooldown = {102280, 102401},
 	  smallCooldown = true,
+	  barcolors = {
+		debuffmine	= {050/255, 100/255, 255/255, 0.5},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
-	-- Earthwarden
+	-- Frenzied Regen & Earthwarden if talented.
 	self:newSpell({
 	  requiredTree = 3,
 	  stance = 1,
-	  requiredTalent = 16,
-	  playerbuff = 203975,
+	  requiresLevel = 50,
+--	  requiredTalent = 16,
+	  playerbuff = {{22842}, {203975}},
+	  recharge = 22842,
+	  barcolors = {
+		playerbuff	= {101/255, 181/255, 141/255, 0.8},
+		recharge	= {030/255, 222/255, 040/255, 0.4}
+	  },
 	})
 
 	-- Three separate lines for this bar so the starting icon reminds you which CD it is tracking, as soon as you use a mitigation ability it will update.
@@ -500,6 +672,10 @@ function EventHorizon:InitializeClass()
 	  playerbuff = {{192081}, {192083}},
 	  cooldown = 5211,
 	  smallCooldown = true,
+	  barcolors = {
+		playerbuff	= {111/255, 111/255, 151/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Ironfur & Mark of Ursol with Mass Entanglement cooldown at half height.
@@ -511,6 +687,10 @@ function EventHorizon:InitializeClass()
 	  playerbuff = {{192081}, {192083}},
 	  cooldown = 102359,
 	  smallCooldown = true,
+	  barcolors = {
+		playerbuff	= {111/255, 111/255, 151/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Ironfur & Mark of Ursol with Typhoon cooldown at half height.
@@ -522,16 +702,25 @@ function EventHorizon:InitializeClass()
 	  playerbuff = {{192081}, {192083}},
 	  cooldown = 132469,
 	  smallCooldown = true,
+	  barcolors = {
+		playerbuff	= {111/255, 111/255, 151/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
-	-- Frenzied Regeneration
+	--[[ Frenzied Regeneration
 	self:newSpell({
 	  requiredTree = 3,
 	  stance = 1,
 	  requiresLevel = 50,
 	  recharge = 22842,
 	  playerbuff = 22842,
+	  barcolors = {
+		playerbuff	= {101/255, 181/255, 141/255, 0.8},
+		recharge	= {030/255, 222/255, 040/255, 0.4}
+	  },
 	})
+]]
 
 	-- Balance Affinity
 
@@ -541,6 +730,9 @@ function EventHorizon:InitializeClass()
 	  stance = 4,
 	  requiredTalent = 7,
 	  debuff = 93402,
+	  barcolors = {
+		debuffmine	= {121/255, 010/255, 000/255, 0.6},
+	  },
 	})
 
 	-- Starsurge  -- There are two bars for this as it provides two different buffs stacking up to three, the buffs are then consumed by different spell schools separately so both are needed.
@@ -553,6 +745,9 @@ function EventHorizon:InitializeClass()
 	  cast = 197626,
 	  recast = true,
 	  icon = 194153,
+	  barcolors = {
+		playerbuff	= {151/255, 101/255, 161/255, 0.5},
+	  },
 	})
 
 	self:newSpell({
@@ -564,6 +759,9 @@ function EventHorizon:InitializeClass()
 	  cast = 197626,
 	  recast = true,
 	  icon = 190984,
+	  barcolors = {
+		playerbuff	= {252/255, 252/255, 090/255, 0.5},
+	  },
 	})
 
 	-- Feral Affinity
@@ -577,6 +775,9 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  cooldown = {102280, 102401},
 	  smallCooldown = true,
+	  barcolors = {
+		debuffmine	= {191/255, 040/255, 101/255, 0.5}
+	  },
 	})
 
 	-- Rip 
@@ -586,32 +787,43 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 8,
 	  debuff = {1079,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {252/255, 000/255, 060/255, 0.5},
+	  },
 	})
 
 	-- Restoration Affinity
 
-	-- Rejuvenation
+	-- Rejuvenation + Swiftmend CD
 	self:newSpell({
 	  requiredTree = 3,
 	  stance = 0,
 	  requiredTalent = 9,
+	  cooldown = 18562,
+	  smallCooldown = true,
 	  playerbuff = {774,3},
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {232/255, 060/255, 202/255, 0.5}
+	  }
 	})
 
-	-- Regrowth + Swiftmend CD
+--	-- Regrowth
 	self:newSpell({
 	  requiredTree = 3,
 	  stance = 0,
 	  requiredTalent = 9,
 	  playerbuff = {8936,2},
-	  cooldown = 18562,
-	  smallCooldown = true,
 	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 8936,
 	  refreshable = true,
+	  cast = 8936,
 	  recast = true,
+	  barcolors = {
+		casting		= {252/255, 121/255, 000/255, 0.8},
+		playerbuff	= {020/255, 212/255, 050/255, 0.7}
+	  }
 	})
 
 	-- Lunar Beam
@@ -629,6 +841,10 @@ function EventHorizon:InitializeClass()
 	  stance = {0,1,2,3,4},
 	  cooldown = 22812,
 	  playerbuff = 22812,
+	  barcolors = {
+		playerbuff	= {141/255, 070/255, 030/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Rage of the Sleeper
@@ -638,6 +854,10 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  cooldown = 200851,
 	  playerbuff = 200851,
+	  barcolors = {
+		playerbuff	= {202/255, 161/255, 050/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Survival Instincts
@@ -646,6 +866,10 @@ function EventHorizon:InitializeClass()
 	  stance = {0,1,2,3,4},
 	  recharge = 61336,
 	  playerbuff = 61336,
+	  barcolors = {
+		playerbuff	= {232/255, 161/255, 101/255, 0.6},
+		recharge	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Incarnation: Guardian of Ursoc
@@ -655,64 +879,141 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 14,
 	  cooldown = 102558,
 	  playerbuff = 102558,
+	  barcolors = {
+		playerbuff	= {150/255, 000/255, 150/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Restoration bars
-	--Note that there are two, or more, entries for the same spell for many of these bars, this is to have them show up in the correct stances with or without Balance Affinity taken.
-	--I'm sure there will be a few players out there who prefer to be a treant, all this effort was for you.
+	--Note that there are two, or more, entries for the same spell for many of these bars, this is to have them show up in the correct stances with or without Balance Affinity taken. Additionally there will be a few players out there who prefer to be a treant, all this effort was for you.
 
-	-- Lifebloom + Wild Growth CD
+	-- The first spell bar is for Lifebloom. This huge note is so you can get Lifebloom to track your focus frame. As many healers, especially in a dungeon group, will set the tank as their focus so this seemed like a good addition however the default is the same mouseover behaviour as the other spells. Just change the comment markers "--" on the auraunit lines. Do this for the both "Lifebloom + Wild Growth CD" spell bars, I know that seemes excessive but it's the only way I could make it work for people who like being a Treant while healing and sometimes have Balance affinity.
+
+	-- Lifebloom + Wild Growth CD, cast and HT cast
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,4},
 	  requiredTalentUnselected = 7,
 	  requiredLevel = 32,
+	  cast = {48438, 5185},
 	  playerbuff = {33763,1},
 	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 48438,
+--	  auraunit = 'focus',
 	  refreshable = true,
 	  icon = 33763,
 	  cooldown = 48438,
 	  smallCooldown = true,
+	  barcolors = {
+		casting		= {252/255, 121/255, 000/255, 0.8},
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {099/255, 232/255, 121/255, 0.5}
+	  }
 	})
 
-	-- Lifebloom + Wild Growth CD
+	-- Lifebloom + Wild Growth CD, cast and HT cast
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,5},
 	  requiredTalent = 7,
+	  cast = {48438, 5185},
 	  playerbuff = {33763,1},
 	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 48438,
+--	  auraunit = 'focus',
 	  refreshable = true,
 	  icon = 33763,
 	  cooldown = 48438,
 	  smallCooldown = true,
+	  barcolors = {
+		casting		= {252/255, 121/255, 000/255, 0.8},
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {099/255, 232/255, 121/255, 0.5}
+	  }
 	})
 
-	-- Rejuvenation
+	-- Rejuvenation + Swiftmend
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,4},
+	  requiredTalent = 2,
 	  requiredTalentUnselected = 7,
 	  requiredLevel = 10,
 	  playerbuff = {774,3},
+	  cooldown = 18562,
+	  smallCooldown = true,
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
-	  cooldown = 29166,
-	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {232/255, 066/255, 202/255, 0.6}
+	  }
 	})
 
-	-- Rejuvenation
+	-- Rejuvenation + Swiftmend
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,4},
+	  requiredTalent = 3,
+	  requiredTalentUnselected = 7,
+	  requiredLevel = 10,
+	  playerbuff = {774,3},
+	  cooldown = 18562,
+	  smallCooldown = true,
+	  auraunit = usemouseover and 'mouseover' or 'target',
+	  refreshable = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {232/255, 066/255, 202/255, 0.6}
+	  }
+	})
+
+	-- Rejuvenation + Swiftmend
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,4},
+	  requiredTalent = 1,
+	  requiredTalentUnselected = 7,
+	  requiredLevel = 10,
+	  playerbuff = {774,3},
+	  recharge = 18562,
+	  auraunit = usemouseover and 'mouseover' or 'target',
+	  refreshable = true,
+	  barcolors = {
+		recharge	= {171/255, 191/255, 181/255, 0.3},
+		playerbuff	= {232/255, 066/255, 202/255, 0.6}
+	  }
+	})
+
+	-- Rejuvenation + Swiftmend
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,5},
 	  requiredTalent = 7,
+	  requiredTalentUnselected = 1,
 	  playerbuff = {774,3},
+	  cooldown = 18562,
+	  smallCooldown = true,
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
-	  cooldown = 29166,
-	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {232/255, 066/255, 202/255, 0.6}
+	  }
+	})
+
+	-- Rejuvenation + Swiftmend
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,5},
+	  requiredTalent = {1,7},
+	  playerbuff = {774,3},
+	  recharge = 18562,
+	  auraunit = usemouseover and 'mouseover' or 'target',
+	  refreshable = true,
+	  barcolors = {
+		recharge	= {171/255, 191/255, 181/255, 0.3},
+		playerbuff	= {232/255, 066/255, 202/255, 0.6}
+	  }
 	})
 
 	-- Germination
@@ -724,6 +1025,9 @@ function EventHorizon:InitializeClass()
 	  playerbuff = {155777,3},
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
+	  barcolors = {
+		playerbuff	= {171/255, 066/255, 202/255, 0.7}
+	  }
 	})
 
 	-- Germination
@@ -735,90 +1039,77 @@ function EventHorizon:InitializeClass()
 	  playerbuff = {155777,3},
 	  auraunit = usemouseover and 'mouseover' or 'target',
 	  refreshable = true,
+	  barcolors = {
+		playerbuff	= {171/255, 66/255, 202/255, 0.7}
+	  }
 	})
 
-	-- Regrowth + Swiftmend
+	-- Regrowth with Essence of G'Hanir CD at half height.
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,4},
-	  requiredTalent = 2,
-	  requiredTalentUnselected = 7,
 	  requiredLevel = 10,
+	  requiredTalentUnselected = 7,
+	  cooldown = 208253,
+	  cast = 8936,
+	  recast = true,
 	  playerbuff = {8936,2},
-	  cooldown = 18562,
+	  auraunit = usemouseover and 'mouseover' or 'target',
+	  refreshable = true,
 	  smallCooldown = true,
-	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 8936,
-	  refreshable = true,
-	  recast = true,
+	  barcolors = {
+		casting		= {252/255, 121/255, 000/255, 0.8},
+		cooldown	= {202/255, 161/255, 055/255, 0.9},
+		playerbuff	= {022/255, 212/255, 055/255, 0.4}
+	  }
 	})
 
-	-- Regrowth + Swiftmend
-	self:newSpell({
-	  requiredTree = 4,
-	  stance = {0,4},
-	  requiredTalent = 3,
-	  requiredTalentUnselected = 7,
-	  requiredLevel = 10,
-	  playerbuff = {8936,2},
-	  cooldown = 18562,
-	  smallCooldown = true,
-	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 8936,
-	  refreshable = true,
-	  recast = true,
-	})
-
-	-- Regrowth + Swiftmend
-	self:newSpell({
-	  requiredTree = 4,
-	  stance = {0,4},
-	  requiredTalent = 1,
-	  requiredTalentUnselected = 7,
-	  requiredLevel = 10,
-	  playerbuff = {8936,2},
-	  recharge = 18562,
-	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 8936,
-	  refreshable = true,
-	  recast = true,
-	})
-
-	-- Regrowth + Swiftmend
+	-- Regrowth with Essence of G'Hanir CD at half height.
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,5},
 	  requiredTalent = 7,
-	  requiredTalentUnselected = 1,
+	  cooldown = 208253,
+	  cast = 8936,
+	  recast = true,
 	  playerbuff = {8936,2},
-	  cooldown = 18562,
+	  auraunit = usemouseover and 'mouseover' or 'target',
+	  refreshable = true,
 	  smallCooldown = true,
-	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 8936,
-	  refreshable = true,
-	  recast = true,
-	})
-
-	-- Regrowth + Swiftmend
-	self:newSpell({
-	  requiredTree = 4,
-	  stance = {0,5},
-	  requiredTalent = {1,7},
-	  playerbuff = {8936,2},
-	  recharge = 18562,
-	  auraunit = usemouseover and 'mouseover' or 'target',
-	  cast = 8936,
-	  refreshable = true,
-	  recast = true,
+	  barcolors = {
+		casting		= {161/255, 121/255, 000/255, 0.8},
+		cooldown	= {202/255, 161/255, 055/255, 0.9},
+		playerbuff	= {022/255, 212/255, 055/255, 0.4}
+	  }
 	})
 
 	-- Cenarion Ward
 	self:newSpell({
 	  requiredTree = 4,
+	  stance = {0,4},
+	  requiredTalentUnselected = 7,
 	  requiredTalent = 2,
 	  playerbuff = {{102351}, {102352,2}},
 	  cooldown = 102351,
 	  auraunit = usemouseover and 'mouseover' or 'target',
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {151/255, 171/255, 090/255, 0.7}
+	  }
+	})
+
+	-- Cenarion Ward
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,5},
+	  requiredTalent = {2,7},
+	  playerbuff = {{102351}, {102352,2}},
+	  cooldown = 102351,
+	  auraunit = usemouseover and 'mouseover' or 'target',
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {151/255, 171/255, 090/255, 0.7}
+	  }
 	})
 
 --[[
@@ -827,10 +1118,33 @@ function EventHorizon:InitializeClass()
 	  requiredTree = 4,
 	  stance = 0,
 	  requiredLevel = 83,
-	  debuff = {145205,2},
+	  playerbuff = {145205,2},
 	})
 ]]--
 
+	-- Flourish
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,4},
+	  requiredTalent = 21,
+	  requiredTalentUnselected = 7,
+	  cooldown = 197721,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+	  }
+	})
+
+	-- Flourish
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,4},
+	  requiredTalent = {7, 21},
+	  cooldown = 197721,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+	  }
+	})
+
 	-- Ironbark
 	self:newSpell({
 	  requiredTree = 4,
@@ -839,6 +1153,10 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 52,
 	  playerbuff = 102342,
 	  cooldown = 102342,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {161/255, 088/255, 077/255, 0.8}
+	  }
 	})
 
 	-- Ironbark
@@ -849,51 +1167,52 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 52,
 	  playerbuff = 102342,
 	  cooldown = 102342,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {161/255, 088/255, 077/255, 0.8}
+	  }
 	})
 
-	-- Essence of G'Hanir
-	self:newSpell({
-	  requiredTree = 4,
-	  stance = {0,4},
-	  requiredTalentUnselected = 7,
-	  requiredArtifactTalent  = 208253,
-	  playerbuff = 208253,
-	  cooldown = 208253,
-	})
-
-	-- Essence of G'Hanir
-	self:newSpell({
-	  requiredTree = 4,
-	  stance = {0,5},
-	  requiredTalent = 7,
-	  requiredArtifactTalent  = 208253,
-	  playerbuff = 208253,
-	  cooldown = 208253,
-	})
-
-	-- Omen of Clarity / Moment of Clarity and Tranquility cooldown.
+	-- Omen of Clarity / Moment of Clarity and Innervate cooldown.
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,4},
 	  requiredTalentUnselected = 7,
 	  requiredLevel = 12,
+	  cooldown = 29166,
 	  playerbuff = 16870,
-	  icon = 16870,
-	  channel = {740,2},
-	  cooldown = 740,
 	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {040/255, 090/255, 191/255, 0.5}
+	  }
 	})
 
-	-- Omen of Clarity / Moment of Clarity and Tranquility cooldown.
+	-- Omen of Clarity / Moment of Clarity and Innervate cooldown.
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = {0,5},
 	  requiredTalent = 7,
+	  cooldown = 29166,
 	  playerbuff = 16870,
-	  icon = 16870,
-	  channel = {740,2},
-	  cooldown = 740,
 	  smallCooldown = true,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6},
+		playerbuff	= {040/255, 090/255, 191/255, 0.5}
+	  }
+	})
+
+	-- Barkskin
+	self:newSpell({
+	  requiredTree = 4,
+	  stance = {0,1,2,3,4,5},
+	  requiredLevel = 26,
+	  cooldown = 22812,
+	  playerbuff = 22812,
+	  barcolors = {
+		playerbuff	= {141/255, 070/255, 030/255, 0.8},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Balance Affinity
@@ -905,6 +1224,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 7,
 	  debuff = {164812,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine = {050/255, 100/255, 255/255, 0.5}
+	  },
 	})
 
 	-- Sunfire
@@ -913,6 +1235,9 @@ function EventHorizon:InitializeClass()
 	  stance = 4,
 	  requiredTalent = 7,
 	  debuff = {93402,2},
+	  barcolors = {
+		debuffmine	= {121/255, 010/255, 000/255, 0.6},
+	  },
 	})
 
 	-- Starsurge  -- There are two bars for this as it provides two different buffs stacking up to three, the buffs are then consumed by different spell schools separately so both are needed.
@@ -925,6 +1250,9 @@ function EventHorizon:InitializeClass()
 	  icon = 164547,
 	  cast = 197626,
 	  recast = true,
+	  barcolors = {
+		playerbuff	= {151/255, 101/255, 161/255, 0.5},
+	  },
 	})
 
 	self:newSpell({
@@ -936,6 +1264,9 @@ function EventHorizon:InitializeClass()
 	  icon = 164545,
 	  cast = 197626,
 	  recast = true,
+	  barcolors = {
+		playerbuff	= {252/255, 252/255, 090/255, 0.5},
+	  },
 	})
 
 	-- Feral Affinity
@@ -947,6 +1278,9 @@ function EventHorizon:InitializeClass()
 	   requiredTalent = 8,
 	   debuff = {1822,3},
 	   refreshable = true,
+	  barcolors = {
+		debuffmine	= {191/255, 040/255, 101/255, 0.5}
+	  },
 	})
 
 	-- Rip 
@@ -956,6 +1290,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 8,
 	  debuff = {1079,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {252/255, 000/255, 060/255, 0.5},
+	  },
 	})
 
 	-- Guardian Affinity
@@ -966,9 +1303,12 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  requiredTalent = 9,
 	  cooldown = 33917,
+	  barcolors = {
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
-	-- Trash 
+	-- Thrash 
 	self:newSpell({
 	  requiredTree = 4,
 	  stance = 1,
@@ -976,6 +1316,10 @@ function EventHorizon:InitializeClass()
 	  debuff = {77758,3},
 	  cooldown = 77758,
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {070/255, 050/255, 040/255, 0.6},
+		cooldown	= {171/255, 191/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Ironfur
@@ -984,6 +1328,9 @@ function EventHorizon:InitializeClass()
 	  stance = 1,
 	  requiredTalent = 9,
 	  playerbuff = 192081,
+	  barcolors = {
+		playerbuff	= {040/255, 070/255, 181/255, 0.6}
+	  },
 	})
 
 	-- Frenzied Regeneration
@@ -993,6 +1340,10 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 9,
 	  recharge = 22842,
 	  playerbuff = 22842,
+	  barcolors = {
+		playerbuff	= {101/255, 181/255, 141/255, 0.8},
+		recharge	= {030/255, 222/255, 040/255, 0.4}
+	  },
 	})
 
 	-- Incarnation: Tree of Life
@@ -1014,6 +1365,9 @@ function EventHorizon:InitializeClass()
 	  requiredLevel = 10,
 	  debuff = {164812,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {050/255, 100/255, 255/255, 0.5}
+	  },
 	})
 
 	-- Moonfire
@@ -1023,6 +1377,9 @@ function EventHorizon:InitializeClass()
 	  requiredTalent = 7,
 	  debuff = {164812,2},
 	  refreshable = true,
+	  barcolors = {
+		debuffmine	= {050/255, 100/255, 255/255, 0.5}
+	  },
 	})
 
 	-- Sunfire with Solar Wrath cast.
@@ -1035,6 +1392,9 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  icon = 164815,
 	  cast = 5176,
+	  barcolors = {
+		debuffmine	= {121/255, 010/255, 000/255, 0.6},
+	  },
 	})
 
 	-- Sunfire with Solar Wrath cast.
@@ -1046,6 +1406,9 @@ function EventHorizon:InitializeClass()
 	  refreshable = true,
 	  icon = 164815,
 	  cast = 5176,
+	  barcolors = {
+		debuffmine	= {121/255, 010/255, 000/255, 0.6},
+	  },
 	})
 ]]--
 end


### PR DESCRIPTION
Changed gcdSpellID to Moonfire as they changed the default starting spell order, again.
Added colours to most bars for easier tracking.