### PR TITLE
Hide recharge number.

### DIFF
--- a/EventHorizon/EventHorizon.lua
+++ b/EventHorizon/EventHorizon.lua
@@ -1830,7 +1830,7 @@ local SpellFrame_SPELL_UPDATE_CHARGES = function(self)
 	end
 
 	-- Set the stacks on the icon to be the current number of charges
-	self:SetStacks(current)
+--	self:SetStacks(current)
 end
 
 local SpellFrame_UNIT_SPELL_HASTE = SpellFrame_SPELL_UPDATE_CHARGES


### PR DESCRIPTION
Having worked on quite a few class configs this option makes a mess of other options.
There are a few bars which are tracking a stacking buff and have a recharge underneath them.
Survival Hunter's Mongoose Bite is a singular example, other configs I've got tracking a buff while having the recharge of a different ability underneath the bar.

The display gets VERY confusing if the recharge is displayed numerically as well as graphically, even for setups I'm familiar with I lose track. I'm not sure how it works out which number it displays either, it didn't seem consistent.

I remember this was a requested feature, it seemed a reasonable request but in practice it doesn't work. At the time of the request it wasn't implemented yet, that was just based off the video feedback.