### PR TITLE
Moved config.past and config.future sets into class modules.

### DIFF
--- a/EventHorizon/EventHorizon.lua
+++ b/EventHorizon/EventHorizon.lua
@@ -3450,8 +3450,8 @@ function ns:ApplyConfig()
   setmetatable(config,{__index = ns.config}) -- Set non-overridden values to what is in [my]config.lua
   self:InitializeClass() -- Set config values in class modules
   
-  vars.past = -math.abs(config.past) or -3  -- We really don't want config.past to be positive, so negative absolute values work great here.
-  vars.future = math.abs(config.future) or 9
+  vars.past = -math.abs(config.past or -3)  -- We really don't want config.past to be positive, so negative absolute values work great here.
+  vars.future = math.abs(config.future or 9)
   vars.barheight = config.height or 18
   vars.barwidth = config.width or 150
   vars.barspacing = config.spacing or 0

--- a/EventHorizon/EventHorizon.lua
+++ b/EventHorizon/EventHorizon.lua
@@ -3207,8 +3207,6 @@ function ns:Initialize()
 
   self:ApplyConfig()
 
-  self:InitializeClass()
-
   if self.config.showTrinketBars and self.config.showTrinketBars == true then
     self:NewSpell({slotID = 13})
     self:NewSpell({slotID = 14})
@@ -3450,6 +3448,7 @@ function ns:ApplyConfig()
     config = EventHorizonDBG.profiles[ppc] -- EventHorizon.profiles[ProfileName] = {overriddenConfig}
   end
   setmetatable(config,{__index = ns.config}) -- Set non-overridden values to what is in [my]config.lua
+  self:InitializeClass() -- Set config values in class modules
   
   vars.past = -math.abs(config.past) or -3  -- We really don't want config.past to be positive, so negative absolute values work great here.
   vars.future = math.abs(config.future) or 9

--- a/EventHorizon/config.lua
+++ b/EventHorizon/config.lua
@@ -42,9 +42,6 @@ config.staticheight = 150        -- Changing this to a number will override conf
 config.staticframes = 7          -- When used with config.staticheight, sets a minimum number of bars to use static height settings with. For example, with staticframes = 4 and 3 bars shown, EventHorizon will use normal variable height settings.
 config.hideIcons = false        -- Hides the bar icons completely. This will make the frame a little more narrow, as config.height will no longer add to its width.
 
-config.past = -1.5            -- Number of seconds to show in the past. Default = -3 (yes, it's a negative number)
-config.future = 12            -- Number of seconds to show in the future. Recommended to keep this between 12-18 unless you've got some crazy configuration. Default = 12
-
 config.texturedbars = true        -- You have the choice between textures and solid colors. Remove this or comment it out to see what the solids look like. Default = true
 config.bartexture = "Interface\\Addons\\EventHorizon\\Smooth"  -- Full path, minus extension, of the bar texture to use. Default = "Interface\\Addons\\EventHorizon\\Smooth"
 config.texturealphamultiplier = 2    -- Most textures appear darker than a solid color because of the alpha value. To counteract this, the opacity of the color is multiplied by this number before it's applied to a texture.

--- a/EventHorizon/config.lua
+++ b/EventHorizon/config.lua
@@ -42,6 +42,9 @@ config.staticheight = 150        -- Changing this to a number will override conf
 config.staticframes = 7          -- When used with config.staticheight, sets a minimum number of bars to use static height settings with. For example, with staticframes = 4 and 3 bars shown, EventHorizon will use normal variable height settings.
 config.hideIcons = false        -- Hides the bar icons completely. This will make the frame a little more narrow, as config.height will no longer add to its width.
 
+config.past = -1.5            -- Number of seconds to show in the past. Default = -3 (yes, it's a negative number)
+config.future = 12            -- Number of seconds to show in the future. Recommended to keep this between 12-18 unless you've got some crazy configuration. Default = 12
+
 config.texturedbars = true        -- You have the choice between textures and solid colors. Remove this or comment it out to see what the solids look like. Default = true
 config.bartexture = "Interface\\Addons\\EventHorizon\\Smooth"  -- Full path, minus extension, of the bar texture to use. Default = "Interface\\Addons\\EventHorizon\\Smooth"
 config.texturealphamultiplier = 2    -- Most textures appear darker than a solid color because of the alpha value. To counteract this, the opacity of the color is multiplied by this number before it's applied to a texture.

--- a/EventHorizon_Deathknight/config.lua
+++ b/EventHorizon_Deathknight/config.lua
@@ -1,5 +1,7 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 49998
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- Blood
 

--- a/EventHorizon_Demonhunter/config.lua
+++ b/EventHorizon_Demonhunter/config.lua
@@ -1,5 +1,7 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 162794
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- Havoc
 

--- a/EventHorizon_Druid/config.lua
+++ b/EventHorizon_Druid/config.lua
@@ -3,6 +3,8 @@ local usemouseover = true    -- Make this false or nil (or just delete the line 
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 768 -- Cat Form
   self.config.hastedSpellID = {50769,10} -- Revive
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
     -- Balance bars
 

--- a/EventHorizon_Hunter/config.lua
+++ b/EventHorizon_Hunter/config.lua
@@ -1,5 +1,7 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 982 -- Revive Pet
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- Beastmaster Bars
 

--- a/EventHorizon_Mage/config.lua
+++ b/EventHorizon_Mage/config.lua
@@ -1,6 +1,8 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 118 -- Polymorph
   self.config.hastedSpellID = {118,1.7}
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
   
   -- Arcane
     

--- a/EventHorizon_Monk/config.lua
+++ b/EventHorizon_Monk/config.lua
@@ -3,6 +3,8 @@ local usemouseover = true  -- Make this false or nil (or just delete the line al
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 100780 -- Legacy of the Emperor
   self.config.hastedSpellID = {115178, 10} -- Resuscitate
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- [[ Windwalker ]] --   
   -- rising sun kick

--- a/EventHorizon_Paladin/config.lua
+++ b/EventHorizon_Paladin/config.lua
@@ -3,6 +3,8 @@ local usemouseover = true -- Make this false or nil (or just delete the line alt
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 19750 -- Flash of Light
   self.config.hastedSpellID = {7328,10} -- Redemption, probably not needed at all
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
 
   -- ---------------------------------------

--- a/EventHorizon_Priest/config.lua
+++ b/EventHorizon_Priest/config.lua
@@ -2,6 +2,8 @@ local usemouseover = true -- Make this false or nil (or just delete the line alt
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 528 -- dispel magic
   self.config.hastedSpellID = {2006, 10}-- Resurrection
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- Discipline
 

--- a/EventHorizon_Rogue/config.lua
+++ b/EventHorizon_Rogue/config.lua
@@ -1,5 +1,7 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 1966
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- Assassination
 

--- a/EventHorizon_Shaman/config.lua
+++ b/EventHorizon_Shaman/config.lua
@@ -3,6 +3,8 @@ local usemouseover = true   -- Make this false or nil (or just delete the line a
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 370 -- Searing Totem
   self.config.hastedSpellID = {2008,10} -- Ancestral Spirit
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- Elemental
 

--- a/EventHorizon_Warlock/config.lua
+++ b/EventHorizon_Warlock/config.lua
@@ -1,6 +1,8 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 1454
   self.config.hastedSpellID = {6201, 3} -- Create Healthstone
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- *** Affliction *** --
   -- Unstable Affliction

--- a/EventHorizon_Warrior/config.lua
+++ b/EventHorizon_Warrior/config.lua
@@ -1,5 +1,7 @@
 function EventHorizon:InitializeClass()
   self.config.gcdSpellID = 100
+  self.config.past = -1.5 -- Number of seconds to show in the past. Default = -3
+  self.config.future = 12 -- Number of seconds to show in the future. Default = 12
 
   -- -- Fury
 


### PR DESCRIPTION
I'd feel better having classes expose some subset of config data and letting ApplyConfig resolve the full application itself, but this would be a breaking change for existing user config overrides. (Something to avoid unless necessary IMO)

Fixes #50
