### PR TITLE
Priest config file for 8.0.1 patch.

### DIFF
--- a/EventHorizon_Priest/config.lua
+++ b/EventHorizon_Priest/config.lua
@@ -345,6 +345,7 @@ function EventHorizon:InitializeClass()
   -- Dark Ascention
   self:newSpell({
     requiredTree = 3,
+    requiredTalent = 20,
     cooldown = 280711,
      barcolors   = {
      cooldown    = {171/255, 191/255, 181/255, 0.7},

--- a/EventHorizon_Priest/config.lua
+++ b/EventHorizon_Priest/config.lua
@@ -18,34 +18,59 @@ function EventHorizon:InitializeClass()
     channel = 47540,
     cooldown = 47540,
     smallCooldown = true,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.9},
+     debuffmine  = {252/255, 222/255, 030/255, 0.5}
+     },
   })
 
   -- Purge the Wicked with Smite cast and Penance CD at half height.
   self:newSpell({
     requiredTree = 1,
-    requiredLevel = 4,
     requiredTalent = 16,
-    debuff = {204213, 2},
+    debuff = {204213, 1.5},
     refreshable = true,
     cast = {585, 186263},
     channel = 47540,
     cooldown = 47540,
     smallCooldown = true,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.9},
+     debuffmine  = {252/255, 222/255, 030/255, 0.5}
+     },
+  })
+
+  -- Power Word: Solace
+  self:newSpell({
+    requiredTree = 1,
+    requiredTalent = 9,
+    cooldown = 129250,
   })
 
   -- Schism
   self:newSpell({
     requiredTree = 1,
     requiredTalent = 3,
+    debuff = 214621,
     cast = 214621,
     cooldown = 214621,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.7},
+     debuffmine  = {252/255, 151/255, 222/255, 0.6}
+     },
   })
 
-  -- Power Word: Solace
+  -- Shadow Covenant
   self:newSpell({
     requiredTree = 1,
-    requiredTalent = 10,
-    cooldown = 129250,
+    requiredTalent = 15,
+    cooldown = 204065,
+    debuff = 204065,
+    auraunit = usemouseover and 'mouseover' or 'target',
+     barcolors   = {
+     debuffmine  = {030/255, 010/255, 111/255, 0.7},
+     cooldown    = {141/255, 080/255, 252/255, 0.3},
+     },
   })
 
   -- Divine star
@@ -53,13 +78,23 @@ function EventHorizon:InitializeClass()
     requiredTree = 1,
     requiredTalent = 17,
     cooldown = 110744,
+     barcolors   = {
+     cooldown    = {232/255, 232/255, 121/255, 0.4},
+     },
   })
 
-  -- Power Word: Radiance
+  -- Power Word: Radiance with Atonement buff.  Not really sure this is worth tracking at all, I think it's a raid frame and/or WA thing to track but this way it isn't another bar.
   self:newSpell({
     requiredTree = 1,
     requiredLevel = 52,
     recharge = 194509,
+    playerbuff = 194384,
+    cast = 194509,
+    auraunit = usemouseover and 'mouseover' or 'target',
+     barcolors   = {
+     recharge    = {171/255, 191/255, 181/255, 0.6},
+     playerbuff  = {070/255, 222/255, 121/255, 0.7}
+     },
   })
 
   --Halo
@@ -68,21 +103,16 @@ function EventHorizon:InitializeClass()
     requiredTalent = 18,
     cast = 120517,
     cooldown = 120517,
+     barcolors   = {
+     cooldown    = {232/255, 232/255, 121/255, 0.4},
+     },
   })
 
   -- Mindbender
   self:newSpell({
     requiredTree = 1,
-    requiredTalent = 12,
+    requiredTalent = 8,
     cooldown = 123040,
-  })
-
-  -- Light's Wrath
-  self:newSpell({
-    requiredTree = 1,
-    requiredArtifactTalent = 207946,
-    cast = 207946,
-    cooldown = 207946,
   })
 
   -- Evangelism
@@ -90,34 +120,28 @@ function EventHorizon:InitializeClass()
     requiredTree = 1,
     requiredTalent = 21,
     cooldown = 246287,
-  })
-
-  -- Power Infusion
-  self:newSpell({
-    requiredTree = 1,
-    requiredTalent = 19,
-    playerbuff = 10060,
-    cooldown = 10060,
+     barcolors   = {
+     cooldown    = {242/255, 181/255, 131/255, 0.4}
+     },
   })
 
   -- Shadowfiend
   self:newSpell({
     requiredTree = 1,
     requiredLevel = 40,
-    requiredTalentUnselected = 12,
+    requiredTalentUnselected = 8,
     cooldown = 34433,
   })
 
-  -- Atonement and Power World: Shield CD at half height.
+  --[[ Atonement
   self:newSpell({
     requiredTree = 1,
     requiredLevel = 8,
     playerbuff = 194384,
     auraunit = usemouseover and 'mouseover' or 'target',
     refreshable = true,
-    cooldown = 17,
-    smallCooldown = true,
   })
+]]
 
   -- Holy
 
@@ -125,44 +149,75 @@ function EventHorizon:InitializeClass()
     self:newSpell({
     requiredTree = 2,
     cast = {585, 14914, 2060, 2061, 33076, 596, 32546},
-    debuff = 14914,
+    debuff = {14914, 1},
     cooldown = 14914,
+    icon = 14914,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.6},
+     debuffmine  = {252/255, 202/255, 121/255, 0.7},
+     },
   })
 
-  --Renew with Chastise CD at half height
+  -- Divine star
   self:newSpell({
     requiredTree = 2,
-    playerbuff = {139, 3},
+    requiredTalent = 17,
+    cooldown = 110744,
+     barcolors   = {
+     cooldown    = {232/255, 232/255, 121/255, 0.4},
+     },
+  })
+
+  --Renew with Holy Word: Chastise CD at half height
+  self:newSpell({
+    requiredTree = 2,
+    playerbuff = 114255,
     cooldown = 88625,
     smallCooldown = true,
-    auraunit = target and 'mouseover' or 'target',
-    refreshable = true,
+     barcolors   = {
+     cooldown    = {222/255, 090/255, 090/255, 0.8},
+     playerbuff  = {252/255, 202/255, 020/255, 0.5},
+     },
   })
 
   --Prayer of Mending
   self:newSpell({
     requiredTree = 2,
+    playerbuff = {139, 3},
+    refreshable = true,
+    auraunit = usemouseover and 'mouseover' or 'target',
     cooldown = 33076,
-    auraunit = target and 'mouseover' or 'target',
+--    smallCooldown = true,
+    icon = 33076,
+     barcolors   = {
+     cooldown    = {232/255, 232/255, 121/255, 0.9},
+     playerbuff  = {111/255, 242/255, 121/255, 0.4}
+     },
+  })
+
+  -- Circle of healing
+  self:newSpell({
+    requiredTree = 2,
+    requiredTalent = 15,
+    cooldown = 204883,
   })
 
   -- Holy word : Serenity
   self:newSpell({
     requiredTree = 2,
     cooldown = 2050,
+     barcolors   = {
+     cooldown    = {151/255, 242/255, 252/255, 0.5},
+     },
   })
 
   -- Holy word: Sanctify
   self:newSpell({
     requiredTree = 2,
     cooldown = 34861,
-  })
-
-  -- Circle of healing
-  self:newSpell({
-    requiredTree = 2,
-    requiredTalent = 21,
-    cooldown = 204883,
+     barcolors   = {
+     cooldown    = {252/255, 252/255, 111/255, 0.6},
+     },
   })
 
   --Halo
@@ -171,32 +226,28 @@ function EventHorizon:InitializeClass()
     requiredTalent = 18,
     cast = 120517,
     cooldown = 120517,
-  })
-
-  -- Divine star
-  self:newSpell({
-    requiredTree = 2,
-    requiredTalent = 17,
-    cooldown = 110744,
+     barcolors   = {
+     cooldown    = {232/255, 232/255, 121/255, 0.4},
+     },
   })
 
   -- Shadow
 
-  -- Vampiric Touch & Void Torrent channel and CD at half height.
+  -- Vampiric Touch & Void Torrent channel and CD at half height if you took the talent.
   self:newSpell({
     requiredTree = 3,
     cast = 34914,
     channel = {205065, 4},
     debuff = {34914, 3},
     refreshable = true,
-    cooldown = 205065,
+    cooldown = 263165,
     smallCooldown = true,
     recast = true,
-    barcolors = {
-      cooldown = {202/255, 161/255, 050/255, 0.7},
-      channeltick= {232/255, 000/255, 000/255, 0.7},
-      debuffmine = {000/255, 090/255, 101/255, 0.5}
-    },
+     barcolors   = {
+     cooldown    = {202/255, 161/255, 050/255, 0.7},
+     channeltick = {232/255, 000/255, 000/255, 0.7},
+     debuffmine  = {000/255, 090/255, 101/255, 0.5}
+     },
   })
 
   -- Shadow Word: Pain & Void Bolt CD.
@@ -207,86 +258,97 @@ function EventHorizon:InitializeClass()
     cast = 228260,
     cooldown = 205448,
     smallCooldown = true,
-    barcolors = {
-      cooldown = {242/255, 020/255, 252/255, 0.9},
-      casting = {242/255, 020/255, 252/255, 0.9},
-      debuffmine = {252/255, 222/255, 030/255, 0.5}
-    },
+     barcolors   = {
+     cooldown    = {242/255, 020/255, 252/255, 0.9},
+     casting     = {242/255, 020/255, 252/255, 0.9},
+     debuffmine  = {252/255, 222/255, 030/255, 0.5}
+     },
   })
 
-  -- Mind Blast/Mind Flay
+  -- Mind Blast CD with Mind Flay/Sear channel and Shadowy Insight proc if selected (instant MB).
   self:newSpell({
     requiredTree = 3,
+    requiredTalentUnselected = 3,
     cast = 8092,
-    channel = {15407, 4},
+    channel = {{15407, 4}, {48045,4}},
     cooldown = 8092,
     playerbuff = 124430,
     icon = 8092,
-    barcolors = {
-      cooldown = {171/255, 191/255, 181/255, 0.6},
-      --casting = {232/255, 202/255, 232/255, 0.5},
-      playerbuff = {252/255, 202/255, 121/255, 0.7},
-      channeltick= {232/255, 000/255, 000/255, 0.7}
-    },
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.6},
+     playerbuff  = {252/255, 202/255, 121/255, 0.7},
+     channeltick = {232/255, 000/255, 000/255, 0.7}
+     },
   })
 
-  -- Shadow Word: Death and Void Ray buff, if talent taken.
+  -- Shadow Word: Void recharge with Mind Flay/Sear channel and Shadowy Insight proc if selected (instant SW:V).
   self:newSpell({
     requiredTree = 3,
-    requiredLevel = 46,
-    recharge = 32379,
-    icon = 32379,
-    playerbuff = 205371,
-    barcolors = {
-      recharge = {212/255, 000/255, 000/255, 0.7},
-      playerbuff = {141/255, 050/255, 171/255, 0.4}
-    },
+    requiredTalent = 3,
+    cast = 205351,
+    channel = {{15407, 4}, {48045,4}},
+    recharge = 205351,
+    playerbuff = 124430,
+    icon = 8092,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.6},
+     playerbuff  = {252/255, 202/255, 121/255, 0.7},
+     channeltick = {232/255, 000/255, 000/255, 0.7}
+     },
   })
 
-  -- Shadow Word: Void
+  -- Shadow Word: Death
   self:newSpell({
-  requiredTree = 3,
-  requiredTalent = 3,
-  cast = 205351,
-  recharge = 205351,
-  barcolors = {
-       recharge = {171/255, 131/255, 222/255, 0.6},
+    requiredTree = 3,
+    requiredTalent = 14,
+    recharge = 32379,
+    icon = 32379,
+     barcolors    = {
+     recharge     = {212/255, 000/255, 000/255, 0.7},
      },
   })
 
   -- Shadow Crash
   self:newSpell({
     requiredTree = 3,
-    requiredTalent = 20,
+    requiredTalent = 15,
     cast = 205385,
     cooldown = 205385,
-    barcolors = {
-      cooldown = {171/255, 191/255, 181/255, 0.6},
+    barcolors    = {
+      cooldown   = {171/255, 191/255, 181/255, 0.6},
     },
   })
 
-  -- Power Infusion
+  -- Dark Void
   self:newSpell({
     requiredTree = 3,
-    requiredTalent = 16,
-    playerbuff = 10060,
-    cooldown = 10060,
-    barcolors = {
-      cooldown = {171/255, 191/255, 181/255, 0.6},
-      playerbuff = {252/255, 242/255, 050/255, 0.7}
-    },
+    requiredTalent = 9,
+    cast = 263346,
+    cooldown = 263346,
+     barcolors   = {
+     cooldown    = {171/255, 131/255, 222/255, 0.6},
+     },
   })
 
-  -- Shadowfiend / Mindbender
+  -- Shadowfiend / Mindbender with Voidform buff, for the stack count, plus Lingering Sanity, also for the stack count.
   self:newSpell({
     requiredTree = 3,
+    playerbuff =  {{194249}, {197937}},
     cooldown = {200174, 34433},
-    playerbuff = 63619,
-    auraunit = 'none',
-    barcolors = {
-      cooldown = {171/255, 191/255, 181/255, 0.6},
-      playerbuff = {191/255, 161/255, 202/255, 0.7}
-    },
+    smallCooldown = true,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.7},
+     playerbuff  = {252/255, 151/255, 222/255, 0.4}
+     },
+  })
+
+  -- Dark Ascention
+  self:newSpell({
+    requiredTree = 3,
+    cooldown = 280711,
+     barcolors   = {
+     cooldown    = {171/255, 191/255, 181/255, 0.7},
+     },
   })
 
 end


### PR DESCRIPTION
Updated the bars to account for the talent position changes, additions or removals.
Added colour to most of the spells for all specs, the idea being that you'll get used to it and be able to tell what is coming off CD without specifically looking at it. I've tried to make the bar colour similar to the icon's but as Disc and Holy have so many with a similar colour I had to choose something.

Changed the bar orders a bit to fit a common theme.
Offensive spells first, even for healers as healer DPS seems to be something Blizzard want us to do in between healing. This is also what Event Horizon does best.
If spells have a CD the order is shortest first then working down, this works for healing spell CD too, they start after the DPS bars, which for priest is pretty quickly.

While Renew and Atonement are tracked via mouseover they don't have their own bars, Renew is on the _Prayed of Mending_ bar and Atonement is on the _Power Word: Radiance_ bar.
I've made this change to keep the bar count down and also because I'd be astounded if anyone uses EH this way, you'll have those buffs on your party/raid frames.
We can't track the number of players with Atonement, not sure if we'll even be able to do that.
I suspect most of you have a WA for it already, or a specific healing mod for it. ;-)